### PR TITLE
Enumerate and rethink the prettify class category usages

### DIFF
--- a/lang-rebol.js
+++ b/lang-rebol.js
@@ -49,87 +49,152 @@
  *
  */
 
+/**
+ * Token style names that correspond to css classes:
+ *
+ * str		(string)
+ * kwd		(keyword)
+ * com		(comment)
+ * typ		(type)
+ * lit		(literal)
+ * pun		(punctuation)
+ * pln		(plain)
+ * tag		(sgml tag)
+ * dec		(declaration)
+ * src		(embedded source)
+ * atn		(sgml attribute name)
+ * atv		(sgml attribute value)
+ * nocode	(not code...e.g. line number)
+ *
+ * You can add new classes.  But standard stylesheets and themes
+ * in use know about those because they are standardized in
+ * prettify.js.  Others that some stylesheets seem to know about:
+ *
+ * opn		(opening punctuation character)
+ * clo		(closing punctuation character)
+ * fun		(a function name)
+ * htm		(an html tag)
+ * xsl		(an xslt tag)
+ */
+
+/**
+ * This file confuses syntax highlighters like Sublime Edit's
+ * So there are "close" comments to get the highlighter back on track.
+ */
+
 PR['registerLangHandler'](
-    PR['createSimpleLexer'](
-        [
-         // Rebol block/parens.  Is opn/clo really needed for Rebol?
-         ['opn',             /^[\(\[]+/, null, '(['],
-         ['clo',             /^[\)\]]+/, null, ')]'],
-         //
-         // Whitespace
-         [PR['PR_PLAIN'],       /^[\t\n\r \xA0]+/, null, '\t\n\r \xA0'],
-         //
-         // Multi-line string {braces} - allowed within:  { ^{ ^}  
-         [PR['PR_STRING'],      /^\{(?:[^\}\^]|\^[\s\S])*(?:\}|$)/, null, '{}'],
-        ],
-        [
-         //
-         // Schemes ("Generic" RE) - Must be before get-word! to avoid conflict
-         [PR['PR_LITERAL'], /^\w+\:\/\/[\w\d\+\-\.\,\%\/]+\b/],
-         //
-         // Types
-         // -- money!
-         [PR['PR_LITERAL'], /^\$\d[\d\.\,\']*\b/],
-         [PR['PR_LITERAL'], /^[\+\-\w]{1,4}\$\d[\d\.\,\']*\b/],
-         // -- date!
-         [PR['PR_LITERAL'], /^\d{1,2}[\-\/](\d{1,2}|\w{3,9})[\-\/]\d{2,4}\/\d{1,2}\:\d{1,2}\:\d{1,2}(\+|\-)\d{1,2}\:(00|30)\b/],
-         [PR['PR_LITERAL'], /^\d{1,2}[\-\/](\d{1,2}|\w{3,9})[\-\/]\d{2,4}\/\d{1,2}\:\d{1,2}\:\d{1,2}\b/],
-         [PR['PR_LITERAL'], /^\d{1,2}[\-\/](\d{1,2}|\w{3,9})[\-\/]\d{2,4}\b/],
-         // -- time!
-         [PR['PR_LITERAL'], /^\d{1,2}\:\d{1,2}\:\d{1,2}\b/],
-         [PR['PR_LITERAL'], /^\d{1,2}\:\d{1,2}\b/],
-         // -- char!
-         [PR['PR_LITERAL'], /^\#\"(?:[^\"\\]|\\[\s\S])*(?:\"|$)/],
-         // -- pair!
-         [PR['PR_LITERAL'], /^\d(?:[\.\,\'\d]*)x\d(?:[\.\,\'\d]*)\b/],
-         // -- string!
-         [PR['PR_STRING'], /^\"(?:[^\"\\]|\\[\s\S])*(?:\"|$)/],
-         // -- issue!
-         [PR['PR_LITERAL'], /^\#[\w\d\-]+\b/],
-         // -- binary!
-         [PR['PR_LITERAL'], /^\#\{(?:[^\}\\]|\\[\s\S])*(?:\}|$)/],
-         // -- literal!
-         [PR['PR_LITERAL'], /^\#\[(?:[^\]\\]|\\[\s\S])*(?:\]|$)/],
-         // -- file!
-         [PR['PR_LITERAL'], /^\%[\.\w\/\-\\]+/],
-         // -- email!
-         [PR['PR_LITERAL'], /^[\w\d\+\-\.]+\@[\w\d\+\-\.]+\b/],
-         // -- tuple!
-         [PR['PR_LITERAL'], /^\d+\.\d+\.\d+\.\d+/],
-         [PR['PR_LITERAL'], /^\d+\.\d+\.\d+/],
-         // -- decimal!
-         [PR['PR_LITERAL'], /^(\+|\-|\d)\d*(?:[\.\,]\d+)\b/],
-         // -- percent!
-         [PR['PR_LITERAL'], /^(\+|\-|\d)(?:[\.\,\'\d]*)\%/],
-         // -- integer!
-         [PR['PR_LITERAL'], /^(\+|\-|\d)\d*\b/],
-         // -- get-word!
-         [PR['PR_LITERAL'], /^\:(?:[A-Za-z0-9=\-\!\?\_\*\+\.\/\'\~]*)/],
-         // -- lit-word!
-         [PR['PR_LITERAL'], /^\'(?:[A-Za-z0-9=\-\!\?\_\*\+\.\/\'\~]*)/],
-         // -- set-word!
-         [PR['PR_DECLARATION'], /^(?:[A-Za-z0-9=\-\!\?\_\*\+\.\/\'\~]*)\:\s/],
-         //
-         // Above is the Rebol data types grammar.  
-         // Below the grammar for type! (declarations)
-         [PR['PR_TYPE'],  /\b(?:[A-Za-z0-9=\-\?\_\*\+\.\/]+)\!/],
-         //
-         // Keywords
-         [PR['PR_KEYWORD'], /\b(?:to\-relative\-file\/as\-local|to\-relative\-file\/as\-rebol|to\-relative\-file\/no\-copy|load\-extension\/dispatch|map\-gob\-offset\/reverse|collect\-words\/ignore|request\-file\/filter|arctangent\/radians|round\/half\-ceiling|request\-file\/multi|to\-local\-file\/full|collect\-words\/deep|request\-file\/title|request\-file\/save|collect\-words\/set|request\-file\/file|greater\-or\-equal\?|strict\-not\-equal\?|arccosine\/radians|lesser\-or\-equal\?|invalid\-utf\?\/utf|unprotect\/values|decompress\/limit|to\-relative\-file|transcode\/error|decompress\/part|round\/half\-down|difference\/case|arcsine\/radians|difference\/skip|decompress\/gzip|recycle\/torture|minimum\-of\/skip|checksum\/secure|recycle\/ballast|clean\-path\/only|extract\/default|maximum\-of\/skip|tangent\/radians|unprotect\/words|checksum\/method|import\/no\-share|charset\/length|resolve\/extend|construct\/with|intersect\/skip|intersect\/case|select\/reverse|switch\/default|uppercase\/part|map\-gob\-offset|encode\/options|construct\/only|transcode\/next|unprotect\/deep|load\-extension|clean\-path\/dir|protect\/values|lowercase\/part|import\/version|import\/no\-user|trace\/function|transcode\/only|dump\-obj\/match|cosine\/radians|reword\/escape|import\/no\-lib|to\-local\-file|new\-line\/skip|random\/secure|save\/compress|make\-dir\/deep|delta\-profile|to\-rebol\-file|reduce\/no\-set|compress\/part|stats\/profile|shift\/logical|round\/ceiling|strict\-equal\?|checksum\/hash|to\-refinement|any\-function\?|checksum\/part|collect\-words|protect\/words|extract\/index|compress\/gzip|array\/initial|import\/check|sort\/reverse|new\-line\/all|sort\/compare|checksum\/tcp|resolve\/only|checksum\/key|speed\?\/no\-io|speed\?\/times|collect\/into|sine\/radians|extract\/into|invalid\-utf\?|compose\/deep|compose\/into|break\/return|protect\/hide|protect\/deep|write\/append|funct\/extern|confirm\/with|encloak\/with|request\-file|replace\/tail|deline\/lines|replace\/case|exclude\/case|find\/reverse|exclude\/skip|module\/mixin|compose\/only|reverse\/part|decloak\/with|cause\-error|assert\/type|select\/part|select\/skip|select\/only|select\/last|remold\/flat|select\/case|limit\-usage|recycle\/off|select\/with|to\-datatype|load\/header|unique\/skip|say\-browser|save\/length|random\/seed|reduce\/into|save\/header|unique\/case|random\/only|launch\/wait|find\-script|launch\/args|append\/part|quit\/return|reduce\/only|append\/only|to\-function|make\-banner|round\/floor|refinement\?|any\-string\?|do\-callback|now\/precise|read\/string|now\/weekday|stats\/timer|insert\/part|reword\/into|insert\/only|stats\/evals|return\/redo|now\/yearday|any\-object\?|stack\/limit|stack\/depth|resolve\/all|to\-get\-path|write\/allow|square\-root|to\-get\-word|enbase\/base|write\/lines|change\/part|change\/only|to\-hex\/size|to\-lit\-path|unbind\/deep|to\-set\-path|to\-lit\-word|replace\/all|repend\/part|repend\/only|to\-set\-word|remove\/part|remove\-each|remold\/only|stack\/block|do\-commands|debase\/base|to\-typeset|entab\/size|remold\/all|round\/down|round\/even|file\-type\?|difference|detab\/size|delta\-time|find\/match|repend\/dup|write\/seek|write\/part|maximum\-of|alter\/case|any\-block\?|trim\/lines|delect\/all|minimum\-of|try\/except|append\/dup|to\-integer|to\-decimal|select\/any|recycle\/on|decompress|decode\-url|mkdir\/deep|apply\/only|copy\/types|arctangent|format\/pad|read\/lines|to\-command|to\-closure|open\/allow|list\-dir\/r|set\-scheme|list\-dir\/l|list\-dir\/i|funct\/with|to\-percent|list\-dir\/f|query\/mode|complement|list\-dir\/d|throw\/name|not\-equal\?|union\/skip|type\?\/word|clean\-path|union\/case|not\-equiv\?|split\-path|split\/into|switch\/all|change\/dup|change\-dir|stack\/args|parse\/case|boot\-print|stats\/show|catch\/quit|catch\/name|stack\/func|insert\/dup|stack\/size|open\/write|stack\/word|trace\/back|loud\-print|remainder|open\/read|open\/seek|call\/wait|to\-string|parse\/all|positive\?|bind\/only|intersect|to\-object|bind\/copy|what\/args|to\-module|now\/month|values\-of|sort\/skip|sort\/case|to\-vector|new\-line\?|take\/deep|take\/last|take\/part|get\-word\?|to\-binary|negative\?|move\/skip|to\-bitset|move\/part|get\-path\?|function\?|set\-word\?|construct|set\-path\?|index\?\/xy|lit\-path\?|lit\-word\?|mold\/only|copy\/deep|copy\/part|mold\/flat|read\/part|arccosine|load\/next|load\/type|read\/seek|modified\?|transcode|datatype\?|find\/with|find\/tail|lowercase|find\/skip|find\/part|find\/last|trim\/with|trim\/tail|find\/case|trim\/head|trim\/auto|any\-word\?|any\-path\?|delect\/in|unprotect|uppercase|map\-event|encoding\?|selfless\?|find\/only|sort\/part|to\-tuple|map\-each|trim\/all|make\-dir|dump\-obj|absolute|subtract|checksum|bind\/set|to\-issue|bind\/new|find\-all|find\/any|closure\?|to\-money|rebcode\?|load\/all|mold\/all|load\-gui|to\-image|sort\/all|to\-paren|list\-env|do\-codec|list\-dir|round\/to|save\/all|multiply|case\/all|to\-error|wait\/all|library\?|new\-line|function|q\/return|greater\?|ask\/hide|command\?|title\-of|to\-logic|words\-of|types\-of|decimal\?|now\/date|to\-block|compress|what\-dir|now\/time|help\/doc|integer\?|now\/year|percent\?|now\/zone|continue|to\-email|typeset\?|to\-event|open\/new|quit\/now|undirize|replace|offset\?|set\/any|confirm|object\?|set\/pad|context|number\?|to\-date|set\-env|arcsine|to\-port|if\/else|as\-pair|to\-char|pending|seventh|series\?|now\/utc|now\/day|wake\-up|to\-file|to\-pair|latin1\?|decloak|compose|protect|to\-word|handle\?|single\?|get\/any|get\-env|default|length\?|script\?|scalar\?|to\-time|native\?|tangent|attempt|move\/to|binary\?|body\-of|license|bitset\?|forskip|to\-path|forever|foreach|collect|recycle|do\/args|string\?|do\/next|module\?|upgrade|closure|vector\?|action\?|spec\-of|reflect|struct\?|reverse|extract|changes|minimum|exists\?|exclude|resolve|maximum|encloak|suffix\?|lesser\?|charset|tuple\?|error\?|equiv\?|repeat|equal\?|rename|enline|encode|event\?|enbase|switch|email\?|either|remove|eighth|extend|remold|return|unset\?|rejoin|reform|reword|update|reduce|first\+|unless|forall|format|divide|dirize|found\?|block\?|fourth|frame\?|utype\?|random|deline|delete|delect|bound\?|unique|assert|repend|secure|select|to\-map|decode|printf|ascii\?|debase|browse|create|cosine|value\?|unbind|image\?|paren\?|import|to\-tag|in\-dir|index\?|object|insert|intern|issue\?|to\-url|append|to\-gob|launch|negate|native|to\-hex|money\?|mold64|modulo|log\-10|module|modify|change|source|logic\?|speed\?|action|second|empty\?|zero\?|char\?|check|stack|clear|close|catch|size\?|sixth|sign\?|shift|stats|date\?|break|dehex|same\?|detab|usage|round|until|unset|entab|even\?|evoke|bind\?|fifth|file\?|first|tail\?|funco|while|quote|word\?|funct|split|q\/now|task\?|tenth|third|throw|union|time\?|probe|print|power|head\?|port\?|path\?|past\?|array|parse|pair\?|apply|open\?|info\?|input|last\?|none\?|write|alter|ninth|trace|ajoin|type\?|log\-2|log\-e|mkdir|true\?|query|about|echo|task|take|tail|tag\?|swap|sort|skip|sine|bind|save|bugs|read|quit|what|prin|poke|pick|call|xor\~|open|case|odd\?|wait|why\?|next|move|more|mold|chat|exit|demo|map\?|trim|back|make|ls\/r|ls\/l|ls\/i|ls\/f|ls\/d|dir\?|url\?|loop|load|last|join|docs|also|help|head|does|halt|gob\?|and\~|func|form|dump|find|copy|utf\?|set|for|and|get|any|has|all|ask|add|try|use|exp|max|min|mod|xor|now|op\?|or\~|pwd|abs|map|not|rm|at|do|dp|ds|dt|cd|in|ls|to|or|if)\s/, null],
-         //
-         // Constants (as literals! - there is no Constants token in GCP)
-         [PR['PR_LITERAL'], /^\b(?:none|true|false|yes|no|on|off)\b/],
-         //
-         // Multi-line comment
-         [PR['PR_COMMENT'],      /^comment\s*\{(?:[^\}\^]|\^[\s\S])*(?:\}|$)/],
-         //
-         // Script tag (shebang!)
-         [PR['PR_COMMENT'], /^#!(?:.*)/],
-         //
-         // A line comment that starts with ;
-         [PR['PR_COMMENT'],     /^;[^\r\n]*/, null, ';'],
-         //
-         // Punctuation (from lisp)
-         [PR['PR_PUNCTUATION'], /^[^\w\t\n\r \xA0()\"\\\';]+/]
-        ]),
-    ['rebol', 'red']);
+	PR['createSimpleLexer']([
+		// Rebol block/parens.  Is opn/clo really needed for Rebol?
+	/*	['opn', /^[\(\[]+/, null, '(['],
+		['clo', /^[\)\]]+/, null, ')]'], */
+
+		// Whitespace
+		['pln', /^[\t\n\r \xA0]+/, null, '\t\n\r \xA0'],
+
+		// Multi-line string {braces} - allowed within:  { ^{ ^}
+		['str', /^\{(?:[^\}\^]|\^[\s\S])*(?:\}|$)/, null, '{}'],
+
+	], [
+
+		// Schemes ("Generic" RE) - Must be before get-word! to avoid conflict
+		['lit', /^\w+\:\/\/[\w\d\+\-\.\,\%\/]+\b/],
+
+		/// TYPES ///
+
+		// -- money!
+		['lit', /^\$\d[\d\.\,\']*\b/], 									/* close ' */
+		['lit', /^[\+\-\w]{1,4}\$\d[\d\.\,\']*\b/], 					/* close ' */
+
+		// -- date!
+		['lit', /^\d{1,2}[\-\/](\d{1,2}|\w{3,9})[\-\/]\d{2,4}\/\d{1,2}\:\d{1,2}\:\d{1,2}(\+|\-)\d{1,2}\:(00|30)\b/],
+		['lit', /^\d{1,2}[\-\/](\d{1,2}|\w{3,9})[\-\/]\d{2,4}\/\d{1,2}\:\d{1,2}\:\d{1,2}\b/],
+		['lit', /^\d{1,2}[\-\/](\d{1,2}|\w{3,9})[\-\/]\d{2,4}\b/],
+
+		// -- time!
+		['lit', /^\d{1,2}\:\d{1,2}\:\d{1,2}\b/],
+		['lit', /^\d{1,2}\:\d{1,2}\b/],
+
+		// -- char!
+		['lit', /^\#\"(?:[^\"\\]|\\[\s\S])*(?:\"|$)/],				/* close " */
+
+		// -- pair!
+		['lit', /^\d(?:[\.\,\'\d]*)x\d(?:[\.\,\'\d]*)\b/],			/* close ' */
+
+		// -- string!
+		['str', /^\"(?:[^\"\\]|\\[\s\S])*(?:\"|$)/],					/* close " */
+
+		// -- issue!
+		['lit', /^\#[\w\d\-]+\b/],
+
+		// -- binary!
+		['lit', /^\#\{(?:[^\}\\]|\\[\s\S])*(?:\}|$)/],
+
+		// -- literal!
+		['lit', /^\#\[(?:[^\]\\]|\\[\s\S])*(?:\]|$)/],
+
+		// -- file!
+		['lit', /^\%[\.\w\/\-\\]+/],
+
+		// -- email!
+		['lit', /^[\w\d\+\-\.]+\@[\w\d\+\-\.]+\b/],
+
+		// -- tuple!
+		['lit', /^\d+\.\d+\.\d+\.\d+/],
+		['lit', /^\d+\.\d+\.\d+/],
+
+		// -- decimal!
+		['lit', /^(\+|\-|\d)\d*(?:[\.\,]\d+)\b/],
+
+		// -- percent!
+		['lit', /^(\+|\-|\d)(?:[\.\,\'\d]*)\%/],						/* close ' */
+
+		// -- integer!
+		['lit', /^(\+|\-|\d)\d*\b/],
+
+		// -- get-word!
+		['atv', /^\:(?:[A-Za-z0-9=\-\!\?\_\*\+\.\/\'\~]*)/],		/* close ' */
+
+		// -- lit-word!
+		['src', /^\'(?:[A-Za-z0-9=\-\!\?\_\*\+\.\/\'\~]*)/],		/* close ' */
+
+		// -- set-word!
+		['dec', /^(?:[A-Za-z0-9=\-\!\?\_\*\+\.\/\'\~]*)\:\s/],	/* close ' */
+
+		// -- refinement!
+		// REVIEW: How to keep this from messing up path!
+		/* ['atn', /^\/(?:[A-Za-z0-9=\-\!\?\_\*\+\.\/\'\~]*)\s/],*/	/* close ' */
+
+		// -- tag!
+		['tag', /^<.*>/],
+
+		// -- We allow stylizing of header indicators (CUSTOM CLASS)
+		['hdr', /^\b(?:Rebol|Red)\b/],
+
+		//
+		// Above is the Rebol data types grammar.  
+		// Below the grammar for type! (declarations)
+		//
+
+		['typ',  /\b(?:[A-Za-z0-9=\-\?\_\*\+\.\/]+)\!/],			/* close !/ */
+		
+		// Rebol has no "keywords", but we highlight "default defined words"
+		// This is a long line... look that way ==>
+		// REVIEW: How to make this work on isolated words, not in paths?
+		['kwd', /\b(?:to\-relative\-file\/as\-local|to\-relative\-file\/as\-rebol|to\-relative\-file\/no\-copy|load\-extension\/dispatch|map\-gob\-offset\/reverse|collect\-words\/ignore|request\-file\/filter|arctangent\/radians|round\/half\-ceiling|request\-file\/multi|to\-local\-file\/full|collect\-words\/deep|request\-file\/title|request\-file\/save|collect\-words\/set|request\-file\/file|greater\-or\-equal\?|strict\-not\-equal\?|arccosine\/radians|lesser\-or\-equal\?|invalid\-utf\?\/utf|unprotect\/values|decompress\/limit|to\-relative\-file|transcode\/error|decompress\/part|round\/half\-down|difference\/case|arcsine\/radians|difference\/skip|decompress\/gzip|recycle\/torture|minimum\-of\/skip|checksum\/secure|recycle\/ballast|clean\-path\/only|extract\/default|maximum\-of\/skip|tangent\/radians|unprotect\/words|checksum\/method|import\/no\-share|charset\/length|resolve\/extend|construct\/with|intersect\/skip|intersect\/case|select\/reverse|switch\/default|uppercase\/part|map\-gob\-offset|encode\/options|construct\/only|transcode\/next|unprotect\/deep|load\-extension|clean\-path\/dir|protect\/values|lowercase\/part|import\/version|import\/no\-user|trace\/function|transcode\/only|dump\-obj\/match|cosine\/radians|reword\/escape|import\/no\-lib|to\-local\-file|new\-line\/skip|random\/secure|save\/compress|make\-dir\/deep|delta\-profile|to\-rebol\-file|reduce\/no\-set|compress\/part|stats\/profile|shift\/logical|round\/ceiling|strict\-equal\?|checksum\/hash|to\-refinement|any\-function\?|checksum\/part|collect\-words|protect\/words|extract\/index|compress\/gzip|array\/initial|import\/check|sort\/reverse|new\-line\/all|sort\/compare|checksum\/tcp|resolve\/only|checksum\/key|speed\?\/no\-io|speed\?\/times|collect\/into|sine\/radians|extract\/into|invalid\-utf\?|compose\/deep|compose\/into|break\/return|protect\/hide|protect\/deep|write\/append|funct\/extern|confirm\/with|encloak\/with|request\-file|replace\/tail|deline\/lines|replace\/case|exclude\/case|find\/reverse|exclude\/skip|module\/mixin|compose\/only|reverse\/part|decloak\/with|cause\-error|assert\/type|select\/part|select\/skip|select\/only|select\/last|remold\/flat|select\/case|limit\-usage|recycle\/off|select\/with|to\-datatype|load\/header|unique\/skip|say\-browser|save\/length|random\/seed|reduce\/into|save\/header|unique\/case|random\/only|launch\/wait|find\-script|launch\/args|append\/part|quit\/return|reduce\/only|append\/only|to\-function|make\-banner|round\/floor|refinement\?|any\-string\?|do\-callback|now\/precise|read\/string|now\/weekday|stats\/timer|insert\/part|reword\/into|insert\/only|stats\/evals|return\/redo|now\/yearday|any\-object\?|stack\/limit|stack\/depth|resolve\/all|to\-get\-path|write\/allow|square\-root|to\-get\-word|enbase\/base|write\/lines|change\/part|change\/only|to\-hex\/size|to\-lit\-path|unbind\/deep|to\-set\-path|to\-lit\-word|replace\/all|repend\/part|repend\/only|to\-set\-word|remove\/part|remove\-each|remold\/only|stack\/block|do\-commands|debase\/base|to\-typeset|entab\/size|remold\/all|round\/down|round\/even|file\-type\?|difference|detab\/size|delta\-time|find\/match|repend\/dup|write\/seek|write\/part|maximum\-of|alter\/case|any\-block\?|trim\/lines|delect\/all|minimum\-of|try\/except|append\/dup|to\-integer|to\-decimal|select\/any|recycle\/on|decompress|decode\-url|mkdir\/deep|apply\/only|copy\/types|arctangent|format\/pad|read\/lines|to\-command|to\-closure|open\/allow|list\-dir\/r|set\-scheme|list\-dir\/l|list\-dir\/i|funct\/with|to\-percent|list\-dir\/f|query\/mode|complement|list\-dir\/d|throw\/name|not\-equal\?|union\/skip|type\?\/word|clean\-path|union\/case|not\-equiv\?|split\-path|split\/into|switch\/all|change\/dup|change\-dir|stack\/args|parse\/case|boot\-print|stats\/show|catch\/quit|catch\/name|stack\/func|insert\/dup|stack\/size|open\/write|stack\/word|trace\/back|loud\-print|remainder|open\/read|open\/seek|call\/wait|to\-string|parse\/all|positive\?|bind\/only|intersect|to\-object|bind\/copy|what\/args|to\-module|now\/month|values\-of|sort\/skip|sort\/case|to\-vector|new\-line\?|take\/deep|take\/last|take\/part|get\-word\?|to\-binary|negative\?|move\/skip|to\-bitset|move\/part|get\-path\?|function\?|set\-word\?|construct|set\-path\?|index\?\/xy|lit\-path\?|lit\-word\?|mold\/only|copy\/deep|copy\/part|mold\/flat|read\/part|arccosine|load\/next|load\/type|read\/seek|modified\?|transcode|datatype\?|find\/with|find\/tail|lowercase|find\/skip|find\/part|find\/last|trim\/with|trim\/tail|find\/case|trim\/head|trim\/auto|any\-word\?|any\-path\?|delect\/in|unprotect|uppercase|map\-event|encoding\?|selfless\?|find\/only|sort\/part|to\-tuple|map\-each|trim\/all|make\-dir|dump\-obj|absolute|subtract|checksum|bind\/set|to\-issue|bind\/new|find\-all|find\/any|closure\?|to\-money|rebcode\?|load\/all|mold\/all|load\-gui|to\-image|sort\/all|to\-paren|list\-env|do\-codec|list\-dir|round\/to|save\/all|multiply|case\/all|to\-error|wait\/all|library\?|new\-line|function|q\/return|greater\?|ask\/hide|command\?|title\-of|to\-logic|words\-of|types\-of|decimal\?|now\/date|to\-block|compress|what\-dir|now\/time|help\/doc|integer\?|now\/year|percent\?|now\/zone|continue|to\-email|typeset\?|to\-event|open\/new|quit\/now|undirize|replace|offset\?|set\/any|confirm|object\?|set\/pad|context|number\?|to\-date|set\-env|arcsine|to\-port|if\/else|as\-pair|to\-char|pending|seventh|series\?|now\/utc|now\/day|wake\-up|to\-file|to\-pair|latin1\?|decloak|compose|protect|to\-word|handle\?|single\?|get\/any|get\-env|default|length\?|script\?|scalar\?|to\-time|native\?|tangent|attempt|move\/to|binary\?|body\-of|license|bitset\?|forskip|to\-path|forever|foreach|collect|recycle|do\/args|string\?|do\/next|module\?|upgrade|closure|vector\?|action\?|spec\-of|reflect|struct\?|reverse|extract|changes|minimum|exists\?|exclude|resolve|maximum|encloak|suffix\?|lesser\?|charset|tuple\?|error\?|equiv\?|repeat|equal\?|rename|enline|encode|event\?|enbase|switch|email\?|either|remove|eighth|extend|remold|return|unset\?|rejoin|reform|reword|update|reduce|first\+|unless|forall|format|divide|dirize|found\?|block\?|fourth|frame\?|utype\?|random|deline|delete|delect|bound\?|unique|assert|repend|secure|select|to\-map|decode|printf|ascii\?|debase|browse|create|cosine|value\?|unbind|image\?|paren\?|import|to\-tag|in\-dir|index\?|object|insert|intern|issue\?|to\-url|append|to\-gob|launch|negate|native|to\-hex|money\?|mold64|modulo|log\-10|module|modify|change|source|logic\?|speed\?|action|second|empty\?|zero\?|char\?|check|stack|clear|close|catch|size\?|sixth|sign\?|shift|stats|date\?|break|dehex|same\?|detab|usage|round|until|unset|entab|even\?|evoke|bind\?|fifth|file\?|first|tail\?|funco|while|quote|word\?|funct|split|q\/now|task\?|tenth|third|throw|union|time\?|probe|print|power|head\?|port\?|path\?|past\?|array|parse|pair\?|apply|open\?|info\?|input|last\?|none\?|write|alter|ninth|trace|ajoin|type\?|log\-2|log\-e|mkdir|true\?|query|about|echo|task|take|tail|tag\?|swap|sort|skip|sine|bind|save|bugs|read|quit|what|prin|poke|pick|call|xor\~|open|case|odd\?|wait|why\?|next|move|more|mold|chat|exit|demo|map\?|trim|back|make|ls\/r|ls\/l|ls\/i|ls\/f|ls\/d|dir\?|url\?|loop|load|last|join|docs|also|help|head|does|halt|gob\?|and\~|func|form|dump|find|copy|utf\?|set|for|and|get|any|has|all|ask|add|try|use|exp|max|min|mod|xor|now|op\?|or\~|pwd|abs|map|not|rm|at|do|dp|ds|dt|cd|in|ls|to|or|if)\s/, null],
+		
+		// Words representing literal values
+		['lit', /^\b(?:none|true|false|yes|no|on|off)\b/],
+
+		// Single-line comment, starting with ;
+		['com', /^;[^\r\n]*/, null, ';'],
+
+		// Multi-line comment
+		['com', /^comment\s*\{(?:[^\}\^]|\^[\s\S])*(?:\}|$)/],
+
+		// Script tag (shebang!)
+		['pun', /^#!(?:.*)/],
+
+	]),
+
+	['rebol', 'red']
+);


### PR DESCRIPTION
Evaluating how to display code samples in my new website design.  It's not just Rebol code, so having a generalized system would be nice.  Thought I'd look at what you'd started here...

I went in and enumerated all of what Google Prettify offers.  Turns out you really can make as many classes as you want, they just standardized some of them... and if you want your stylesheet to work you should use styles other people know about.

As "literal" means "constant" in their vernacular, lit-word! shouldn't be a 'lit'.  @rgchris doesn't distinguish between the color of string literals and other kinds of literals, except he colors tags in cyan.  There is an html tag "standard" in Prettify so I used that.

I punned "attribute value" as refinement, but couldn't figure out how to get refinements to only happen when the term started with a slash.  _(Though being RegEx, "couldn't figure out" = "first thing I tried didn't work and I didn't want to try anything else because I cannot stand RegEx".)_  There is a similar problem happening with the keywords registering when they are part of a path.

I also couldn't figure out how to get "Red/System" to identify as the custom HDR type.  `Red\/System` didn't seem to do the trick.

There isn't really any "punctuation" in Rebol, So I just threw it onto the `#!` thing you had as a comment.  Kind of superfluous, just something to think about...
