### PR TITLE
Include file that tries to simulate rgchris’s CSS choices with lang-rebol

### DIFF
--- a/reb4me-prettify.css
+++ b/reb4me-prettify.css
@@ -1,0 +1,58 @@
+/* Pretty printing styles. Used with prettify.js. */
+/* Based on style by Christopher Ross-Gill for http://reb4.me/cc */
+
+@import url('http://fonts.googleapis.com/css?family=Inconsolata:400,700');
+
+/* declaration - blue, bold */
+pre .dec, code .dec { font-weight: bold; color: #004; }
+
+/* lang-rebol.js-defined custom type for header word (e.g. Rebol, Red) */
+pre .hdr, code .hdr { font-weight: bold; color: #004; } 
+
+/* comment - grey italic */
+pre .com, code .com { color: #999; font-style: italic; } 
+
+/* keyword - was red (#900) but disabled until paths like question/get
+   do not highlight the "get" */
+pre .kwd, code .kwd { color: #000; }
+
+pre .opn, code .opn { color: #000; } /* open brace - black */
+pre .clo, code .clo { color: #000; } /* close brace - black */
+pre .lit, code .lit { color: #072; } /* literals - green */
+pre .str, code .str { color: #072; } /* strings - also green */
+pre .tag, code .tag { color: #09A; } /* tag - bright cyan */
+pre .typ, code .typ { color: #736; } /* datatype - maroon */
+pre .pln, code .pln { color: #000; } /* plain code - black */ 
+
+/* lang-rebol.js uses "embedded source" for lit-word - purple */
+pre .src, code .src { color: #606; } 
+
+/* lang-rebol.js uses "attribute name" for refinement - dark yellow */
+/* Note: Currently functionality is buggy and disabled */
+pre .atn, code .atn { color: #972; }
+
+/* lang-rebol.js uses "attribute value" for get-word - black */
+pre .atv, code .atv { color: #000; }
+
+/* lang-rebol.js uses "punctuation" for shell - gray */
+pre .pun, code .pun { color: #777; }
+
+/* round border is from sunburst theme by David Leibovic */
+pre.prettyprint, code.prettyprint {
+	background-color: #FAFAFA;
+	-moz-border-radius: 8px;
+	-webkit-border-radius: 8px;
+	-o-border-radius: 8px;
+	-ms-border-radius: 8px;
+	-khtml-border-radius: 8px;
+	border-radius: 8px;
+
+	font: 1em "Inconsolata","Courier New",fixed;
+}
+
+pre.prettyprint {
+	width: 95%;
+	margin: 1em auto;
+	padding: 1em;
+	white-space: pre-wrap;
+}


### PR DESCRIPTION
I wanted to try and get a stylesheet for Prettify that matched [@rgchris's code colorizer](http://reb4.me/cc), more or less.

Things blocking that is that refinements don't work, and I disabled the keyword highlighting... I am a bit suspicious of highlighting "keywords" in Rebol in the first place.  But both the refinements and the keywords have the problem of highlighting in paths, which they shouldn't.

Anyway, the custom font looks really nice and I'm a big fan of making set-words show up in bold.  That's the most important thing in my view, vs the keywords:

![sample-reb4me](https://f.cloud.github.com/assets/20440/1755957/e02c57de-666c-11e3-82d8-495f90902e97.png)

Thought it would be nice if there was a place to maintain the theme, and perhaps if this is properly generalized it could make it into the [Prettify Themes List](http://google-code-prettify.googlecode.com/svn/trunk/styles/index.html)?
